### PR TITLE
Call Filter function to sidemenu 

### DIFF
--- a/1080i/Component_SideMenu.xml
+++ b/1080i/Component_SideMenu.xml
@@ -624,11 +624,11 @@
     <include name="VideoFilterActivateButtonForSideMenu">
         <definition>
             <control type="button" id="21">
-                <visible>String.IsEmpty(Window.Property(filter))</visible>
+		<visible>String.IsEmpty(Window.Property(filter))</visible>
                 <align>left</align>
                 <label>$LOCALIZE[587]</label>
-                <onclick>SendClick(videos,19)</onclick>
-                <onclick>SetFocus(22)</onclick>
+                <onclick>right</onclick>
+                <onclick>Filter</onclick>
             </control>
         </definition>
     </include>

--- a/1080i/Component_SideMenu.xml
+++ b/1080i/Component_SideMenu.xml
@@ -624,7 +624,7 @@
     <include name="VideoFilterActivateButtonForSideMenu">
         <definition>
             <control type="button" id="21">
-		<visible>String.IsEmpty(Window.Property(filter))</visible>
+	        <visible>String.IsEmpty(Window.Property(filter))</visible>
                 <align>left</align>
                 <label>$LOCALIZE[587]</label>
                 <onclick>right</onclick>


### PR DESCRIPTION
This skin currently doesn't have the option to use filter working (sidemenu).
So this change basically copies what estuary does and works. It shows the filter menu.

Based on:
https://github.com/xbmc/xbmc/blob/master/addons/skin.estuary/xml/Includes_MediaMenu.xml
```
<control type="button" id="199">
	<visible>Container.CanFilterAdvanced</visible>
	<include>MediaMenuItemsCommon</include>
	<label>$LOCALIZE[587]</label>
	<onclick>right</onclick>
	<onclick>Filter</onclick>
</control>
```

I'm not sure what the other options do so I just changed the `onclick` lines.
Sorry about the indentation on line 627 not sure what's happening since on vim all the lines look the same.